### PR TITLE
Add "bin" to install jsdoc-cli-wrapper executable

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "JSDoc command line interface wrapper",
   "main": "index.js",
+  "bin": "./index.js",
   "scripts": {
     "lint": "eslint --color --max-warnings 0 .",
     "test": "vitest",


### PR DESCRIPTION
With this, this module should be ready to publish (I think).

- https://docs.npmjs.com/cli/v10/configuring-npm/package-json#bin

---

Also, in other news, this commit and its PR should finally trigger the coverage/coveralls GitHub Actions check. Coverage from pull requests and pushes to 'main' have posted coverage to Coveralls, the checks just haven't appeared.

The reason appeared to be because the repo appeared to be "ownerless" on https://coveralls.io/. I learned about this from:

- https://github.com/lemurheavy/coveralls-public/issues/1591#issuecomment-956494295
- https://stackoverflow.com/a/76591886
- https://docs.coveralls.io/common-issues-and-troubleshooting#issue-not-getting-status-updates

The latter doc says there's no web UI to chance the owner. However, when I went to https://coveralls.io/github/mbland/jsdoc-cli-wrapper/settings, there was a button I clicked to claim ownership.

The button's not there anymore, so I suppose it should be fixed now. We'll see shortly.