### PR TITLE
End run-tests, publish-test-results actions early

### DIFF
--- a/.github/workflows/publish-test-results.yaml
+++ b/.github/workflows/publish-test-results.yaml
@@ -38,7 +38,6 @@ jobs:
 
       - name: Post test report
         uses: dorny/test-reporter@v1
-        if: always()
         with:
           name: Test Results
           path: 'TESTS-TestSuites.xml'

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -46,6 +46,5 @@ jobs:
 
       - name: Send test coverage to Coveralls.io
         uses: coverallsapp/github-action@v2
-        if: always()
         with:
           file: 'coverage/lcov.info'


### PR DESCRIPTION
The publish-test-results GitHub Actions workflow would keep running even if it failed to download artifacts. run-tests would try to post coverage even if tests failed, when there was no coverage/lcov.info to send.

This change now prevents both of those steps from taking place if an earlier step failed.