### PR TITLE
Add MPL-2.0 header to jsdoc shell stub

### DIFF
--- a/test/fixtures/jsdocStub/jsdoc
+++ b/test/fixtures/jsdocStub/jsdoc
@@ -1,5 +1,9 @@
 #!/bin/sh
 #
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#
 # Wraps the jsdoc.js command on non-Windows platforms.
 #
 # This is necessary to support older Node versions as package.json engines


### PR DESCRIPTION
Should've been part of commit 154efa24467b6f98b6a0c73d50179a29ff8dac97 and #8.

From: https://www.mozilla.org/en-US/MPL/headers/