### PR TITLE
Simplify JSON trailing comment regular expression

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -214,7 +214,7 @@ export function stripJsonComments(jsonStr) {
     }
     result += curChar
   }
-  return result.replaceAll(/,(\s*)([\]}])/g, ' $1$2')
+  return result.replaceAll(/,(\s*[\]}])/g, ' $1')
 }
 
 /**


### PR DESCRIPTION
Not a huge change, but when it comes to regular expressions, every bit of simplification helps—at least when it comes to readability, if not performance.