### PR TITLE
Minor tweaks, v18 test fix, README update

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,21 @@ the path to your JSDoc config file):
 }
 ```
 
+### Opening the link
+
+Running the wrapper will generate the link to the generated `index.html` file, e.g.:
+
+```text
+jsdoc/jsdoc-cli-wrapper/1.0.0/index.html
+```
+
+You can open this link from the command line via the following commands,
+replacing `path/to/index.html` with your actual `index.html` path:
+
+- **macOS**: `open path/to/index.html`
+- **Linux**: `xdg-open path/to/index.html`
+- **Windows**: `start path\to\index.html`
+
 ## Motivation
 
 The `jsdoc` command will:

--- a/lib/index.js
+++ b/lib/index.js
@@ -43,13 +43,13 @@ export async function runJsdoc(argv, env, platform) {
       .on('close', code => resolve(code))
   })
 
-  try {
-    if (exitCode === 0 && willGenerate) {
+  if (exitCode === 0 && willGenerate) {
+    try {
       return {exitCode, indexHtml: await findFile(destination, 'index.html')}
+    } catch {
+      // If jsdoc finds no input files, it doesn't create the directory, but
+      // prints "There are no input files to process." and exits 0.
     }
-  } catch {
-    // If jsdoc finds no input files, it won't create the destination directory.
-    // It will print "There are no input files to process." and exit with 0.
   }
   return {exitCode}
 }
@@ -104,17 +104,14 @@ export async function getPath(cmdName, env, platform) {
  */
 export async function analyzeArgv(argv) {
   const validArg = nextArg => nextArg !== undefined && !nextArg.startsWith('-')
-  let destination = undefined
-  let willGenerate = true
-  let cmdLineDest = false
+  let destination, cmdLineDest, willGenerate = true
 
   for (let i = 0; i !== argv.length; ++i) {
     const arg = argv[i]
     const nextArg = argv[i+1]
 
     switch (arg) {
-    case '-c':
-    case '--configure':
+    case '-c': case '--configure':
       if (!cmdLineDest && validArg(nextArg)) {
         const jsonSrc = await readFile(nextArg, {encoding: 'utf8'})
         const config = JSON.parse(stripJsonComments(jsonSrc))
@@ -122,18 +119,14 @@ export async function analyzeArgv(argv) {
       }
       break
 
-    case '-d':
-    case '--destination':
+    case '-d': case '--destination':
       if (validArg(nextArg)) {
         destination = nextArg
         cmdLineDest = true
       }
       break
 
-    case '-h':
-    case '--help':
-    case '-v':
-    case '--version':
+    case '-h': case '--help': case '-v': case '--version':
       willGenerate = false
       break
     }
@@ -231,11 +224,9 @@ export async function findFile(dirname, filename) {
 
   while ((curDir = childDirs.shift()) !== undefined) {
     // This should be `for await (const entry of readdir(...))`:
-    //
     // - https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/for-await...of
     //
     // But Node 20.10.0 errors with:
-    //
     //   TypeError: readdir(...) is not a function or its return value is not
     //   async iterable
     const entries = await readdir(curDir, {withFileTypes: true})


### PR DESCRIPTION
The changes to lib/index.js are very minor, and largely cosmetic in nature. I also decided to add a short "Opening the link" section to README.md to document the command lines for doing so on different operating systems.

However, the big change ended up being making the "stripJsonComments > maintains correct syntax error position info when" suite compatible with Node.js v18. It turns out the error output from JSON.parse is substantially different from later versions. That said, I'm pretty pleased with the changes to make the tests compatible with v18. These same changes improved the structure and readability of this test suite overall.