### PR TITLE
Bump to v1.0.3, tweak stripJsonComments()

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Running the wrapper will generate the local `file://` URL to the generated
 `index.html` file, e.g.:
 
 ```text
-file:///path/to/jsdoc/output/jsdoc-cli-wrapper/1.0.0/index.html
+file:///path/to/jsdoc/output/jsdoc-cli-wrapper/1.0.3/index.html
 ```
 
 You can click on or copy this link to open it in your browser. You can also open
@@ -99,10 +99,10 @@ This wrapper resolves both of these minor annoyances.
 ```sh
 $ pnpm jsdoc
 
-> jsdoc-cli-wrapper@1.0.1 jsdoc /path/to/jsdoc-cli-wrapper
+> jsdoc-cli-wrapper@1.0.3 jsdoc /path/to/jsdoc-cli-wrapper
 > node index.js -c jsdoc.json .
 
-file:///path/to/jsdoc-cli-wrapper/jsdoc/jsdoc-cli-wrapper/1.0.0/index.html
+file:///path/to/jsdoc-cli-wrapper/jsdoc/jsdoc-cli-wrapper/1.0.3/index.html
 ```
 
 Of course, your own project would use `jsdoc-cli-wrapper` instead of `node

--- a/lib/index.js
+++ b/lib/index.js
@@ -197,10 +197,12 @@ export function stripJsonComments(str) {
         comment = (c === '/') ? 'line' : 'block'
         c = result[i-1] = ' '
       }
+    } else if (c === ',') {
+      comma = i
     } else {  // outside any valid string or comment, replace trailing commas
       if (c === '"') inString = true
       else if (comma && (c === ']' || c === '}')) result[comma] = ' '
-      comma = (c === ',') ? i : null
+      comma = null
     }
     result.push(c)
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsdoc-cli-wrapper",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "JSDoc command line interface wrapper",
   "main": "index.js",
   "bin": "./index.js",


### PR DESCRIPTION
Previously the code always performed the comma check after checking for string openeings or the end of an array or object. This change prevents those other comparisons if we already know the current character is a comma.